### PR TITLE
Lock down CORS allowed hosts to *(|.)data.gov.au

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -605,8 +605,9 @@ gateway:
 
   ## Configures cross-origin resource sharing - will be converted to JSON and passed
   ## to https://www.npmjs.com/package/cors#configuring-cors
-  # cors:
-
+  cors:
+    origin: /data\.gov.au$/
+    
   ## Enables a simple form at /auth that allows you to test login and logout functionality
   ## without needing a web pod
   enableAuthEndpoint: false


### PR DESCRIPTION
Implements intent of https://github.com/magda-io/magda/issues/1348