### PR TITLE
Fixed some rc3 SQL upgrade script issues

### DIFF
--- a/sql-migrations/add-footer-config.sql
+++ b/sql-migrations/add-footer-config.sql
@@ -1,14 +1,8 @@
-
-UPDATE public.content
-SET content = '{"order":10,"label":"Data.gov.au"}'
-WHERE id = 'footer/navigation/small/category/magda2';
-
+INSERT INTO public.content VALUES ('footer/navigation/small/category/magda2', 'application/json', '{"order":10,"label":"Data.gov.au"}');
 INSERT INTO public.content VALUES ('footer/navigation/small/category-links/magda2/signin', 'application/json', '{"order":30,"label":"Sign in","href":"https://data.gov.au/user/login"}');
 INSERT INTO public.content VALUES ('footer/navigation/small/category-links/magda2/feedback', 'application/json', '{"order":40,"label":"Give feedback","href":"feedback"}');
 
-UPDATE public.content
-SET content = '{"order":10,"label":"Data.gov.au"}'
-WHERE id = 'footer/navigation/medium/category/magda';
+INSERT INTO public.content VALUES ('footer/navigation/medium/category/magda', 'application/json', '{"order":10,"label":"Data.gov.au"}');
 INSERT INTO public.content VALUES ('footer/navigation/medium/category-links/magda/feedback', 'application/json', '{"order":40,"label":"Give feedback","href":"feedback"}');
 
 INSERT INTO public.content VALUES ('footer/navigation/medium/category/publishers', 'application/json', '{"order":15,"label":"Publishers"}');


### PR DESCRIPTION
Changes: 
- As migration process will be run DGA scripts before migrator. Those lines should be insert rather than update

@AlexGilleran Previously mentioned (on slack) `DETAIL:  Key (id)=(includeHtml) already exists.` issue was due to existing data in my minikube --- I didn't `kubect delete pvc combined-db-combined-db-0` 😓 
Thus, no changes to `add-third-party-js.sql`