### PR TITLE
Updated broken link minion recrawl period

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -797,6 +797,7 @@ web-server:
 ## Settings for the broken link minion, which crawls URLs of distributions in order
 ## to determine whether they're still available.
 minion-broken-link:
+  schedule: "0 0 */7 * *"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Requires PR https://github.com/magda-io/magda/pull/2132

Updated broken link minion recrawl period.
The current production setting in the cluster is: `0 0 */7 * *` which means `At 00:00 on every 7th day-of-month`
This PR just added the same value to config.yaml.
If we want it run once every week, we probably should change it to: `0 0 * * 6` i.e. `At 00:00 on Saturday.` 
