### PR TITLE
Increase format minion resources

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -468,8 +468,8 @@ magda:
   minion-format:
     resources:
       requests:
-        cpu: 10m
-        memory: 50Mi
+        cpu: 20m
+        memory: 100Mi
       limits:
         cpu: 50m
         memory: 500Mi


### PR DESCRIPTION
### Increase format minion resources
Format minion might sometimes request a bit over 50mi ram for some reason k8s will kill it with 137 exit code.
Has increased the resource in production and will increase in the config as well