### PR TITLE
update vic connector config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -344,6 +344,14 @@ connector-vic:
     sourceUrl: https://discover.data.vic.gov.au/
     pageSize: 100
     schedule: 50 * * * *
+    ignoreHarvestSources: []
+    presetRecordAspects:
+      id: organization-details
+      recordType: Organization
+      data: 
+        title: "Victoria Government"
+        jurisdiction: "Victoria Government"
+
 
 connector-wa:
   config:

--- a/config.yaml
+++ b/config.yaml
@@ -346,7 +346,7 @@ connector-vic:
     schedule: 50 * * * *
     ignoreHarvestSources: []
     presetRecordAspects:
-      id: organization-details
+    - id: organization-details
       recordType: Organization
       data: 
         title: "Victoria Government"


### PR DESCRIPTION
- remove `ignoreHarvestSources`. They only harvest from internal source
- set jurisdiction to `Victoria Government` (as they didn't set it on their end properly)

More details on `presetRecordAspects` see:
https://github.com/magda-io/magda/blob/57d5c8a98086fd9eebe9cd508cbc99ee3e10fec9/magda-typescript-common/src/JsonConnector.ts#L729

